### PR TITLE
Fix device copying latest position

### DIFF
--- a/src/main/java/pl/datamatica/traccar/model/Device.java
+++ b/src/main/java/pl/datamatica/traccar/model/Device.java
@@ -112,6 +112,9 @@ public class Device extends TimestampedEntity implements IsSerializable, Grouped
                 sensors.add(new Sensor(sensor));
             }
         }
+        if (device.latestPosition != null)
+            latestPosition = new Position(device.latestPosition);
+        
         group = device.group == null ? null : new Group(device.group.getId()).copyFrom(device.group);
         deviceModelId = device.deviceModelId;
 


### PR DESCRIPTION
It fixes copying ```latestPosition``` in Device.
It affected GET /devices/<id>

It should be also copied all positions, but I'm not sure about performance...
@UZamkniete what do you think?